### PR TITLE
Revert "chore(deps): update dependency konstruktoid.hardening to v2.0.4"

### DIFF
--- a/testing/requirements.yml
+++ b/testing/requirements.yml
@@ -1,6 +1,6 @@
 ---
 roles:
   - name: konstruktoid.hardening
-    version: 'v2.0.4'
+    version: 'v2.0.3'
     src: https://github.com/konstruktoid/ansible-role-hardening.git
     scm: git


### PR DESCRIPTION
Reverts in order to test that the CI works correctly. Exceptionally bypassing the tests since I do not change the code