### PR TITLE
fix(deps): pin dependencies to minor versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible
-ansible-lint
-passlib
-jmespath
+ansible~=9.5.1
+ansible-lint~=24.2.3
+passlib~=1.7.4
+jmespath~=1.0.1


### PR DESCRIPTION
Pinned the versions of ansible, ansible-lint, passlib, and jmespath in requirements.txt to allow only minor updates. This ensures compatibility while allowing automatic updates to the latest patches without the risk of major version upgrades causing breaking changes.